### PR TITLE
Non-functional font validator

### DIFF
--- a/SourceCode/ETDValidator/ETDValidator/Models/Validators/FontValidator.cs
+++ b/SourceCode/ETDValidator/ETDValidator/Models/Validators/FontValidator.cs
@@ -5,34 +5,48 @@ using DocumentFormat.OpenXml.Packaging;
 using Newtonsoft.Json.Linq;
 using System.Linq;
 using System;
+using System.Xml;
+using System.Xml.Linq;
 using DocumentFormat.OpenXml.Math;
 
 namespace ETDVAlidator.Models.Validators
 {
     public class FontValidator : ComponentValidator
     {
-        
+        private Dictionary<int, string> invalidFamilies = new Dictionary<int, string>();
         public FontValidator()
         {
             Warnings = new List<ComponentWarning>();
             Errors = new List<ComponentError>();
+            
+            invalidFamilies.Add(4, "script");
+            invalidFamilies.Add(5, "decorative");
         }
         
         protected override void ParseContents()
         {
-            // do parsing here, add errors and warnings
-            // DocToValidate is WordprocessignDocument object to parse through 
+            // get list of font classes from document font table 
+            var fonts = DocToValidate.MainDocumentPart.FontTablePart.Fonts;
 
             
-            // these can be deleted - just examples
-            Warnings.Add(new ComponentWarning("font_warning_1", "warning 1 description"));
-            Warnings.Add(new ComponentWarning("font_warning_2", "warning 2 description"));
-            Warnings.Add(new ComponentWarning("font_warning_3", "warning 3 description"));
-
-
-            Errors.Add(new ComponentError("font_error_1", "error 1 description"));
-            Errors.Add(new ComponentError("font_error_2", "error 2 description"));
-            Errors.Add(new ComponentError("font_error_3", "error 3 description"));
+            foreach (var font in fonts)
+            {
+                // each font is represented as an array - the 3rd index holds the font family object
+                var fontFamily = font.ToList()[2];
+                
+                // verify that we pulled the correct attribute
+                if ("family" == fontFamily.LocalName)
+                {
+                    // get the font family name as a string
+                    var family = fontFamily.GetAttributes()[0].Value;
+                    
+                    // create warning if font family is in list of invalid font families
+                    if (invalidFamilies.ContainsValue(family))
+                    {    
+                        Warnings.Add(new ComponentWarning("Invalid Font", "A potentially non-standard font family was used: " + family));
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Overview
### `What is the change?`
- Set up FontValidator to check if a non-standard font family is used (i.e. can't be script or decorative)

- [ ] Bug Fix 
- [x] New Feature
- [ ] Refactoring
- [ ] Other

### Trello card link?
https://trello.com/c/WgqAIsRr/15-implement-font-requirements-checker-five-sub-specifications

## Other Notes/Attachments

## `Meme`
