### PR TITLE
Fix upload validation and get backend JSON into js file

### DIFF
--- a/SourceCode/ETDValidator/ETDValidator/Controllers/HomeController.cs
+++ b/SourceCode/ETDValidator/ETDValidator/Controllers/HomeController.cs
@@ -1,20 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Xml;
-using System.Xml.Linq;
+﻿using System.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using ETDVAlidator.Models;
-using DocumentFormat.OpenXml;
-using DocumentFormat.OpenXml.Packaging;
-using DocumentFormat.OpenXml.Wordprocessing;
-using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Forms;
 
 namespace ETDVAlidator.Controllers
 {

--- a/SourceCode/ETDValidator/ETDValidator/Models/DocumentResultsViewModel.cs
+++ b/SourceCode/ETDValidator/ETDValidator/Models/DocumentResultsViewModel.cs
@@ -1,0 +1,12 @@
+namespace ETDVAlidator.Models
+{
+    public class DocumentResultsViewModel
+    {
+        public string JsonString { get; set; }
+
+        public DocumentResultsViewModel(string jsonString)
+        {
+            JsonString = jsonString;
+        }
+    }
+}

--- a/SourceCode/ETDValidator/ETDValidator/Models/ValidatorModel.cs
+++ b/SourceCode/ETDValidator/ETDValidator/Models/ValidatorModel.cs
@@ -36,7 +36,7 @@ namespace ETDVAlidator.Models
                 }
             };
 
-            return JsonConvert.SerializeObject(returnValueObj, Formatting.Indented);
+            return JsonConvert.SerializeObject(returnValueObj);
         }
         
     }

--- a/SourceCode/ETDValidator/ETDValidator/Models/Validators/MarginValidator.cs
+++ b/SourceCode/ETDValidator/ETDValidator/Models/Validators/MarginValidator.cs
@@ -48,7 +48,6 @@ namespace ETDVAlidator.Models.Validators
                 
                 // Pass that to method for checking header is set to 1" or 1440 twentieths of a point
                 validateHeaderSize(headerMarginXml[5], 1440);
-                Console.Out.Write("Test");
 
             }
                 

--- a/SourceCode/ETDValidator/ETDValidator/Models/Validators/SpacingValidator.cs
+++ b/SourceCode/ETDValidator/ETDValidator/Models/Validators/SpacingValidator.cs
@@ -20,14 +20,8 @@ namespace ETDVAlidator.Models.Validators
             
             
             // these can be deleted - just examples
-            Warnings.Add(new ComponentWarning("spacing_warning_1", "warning 1 description"));
-            Warnings.Add(new ComponentWarning("spacing_warning_2", "warning 2 description"));
-            Warnings.Add(new ComponentWarning("spacing_warning_3", "warning 3 description"));
-
-
-            Errors.Add(new ComponentError("spacing_error_1", "error 1 description"));
-            Errors.Add(new ComponentError("spacing_error_2", "error 2 description"));
-            Errors.Add(new ComponentError("spacing_error_3", "error 3 description"));
+            //Warnings.Add(new ComponentWarning("spacing_warning_1", "warning 1 description"));
+            //Errors.Add(new ComponentError("spacing_error_1", "error 1 description"));
         }
     }
 }

--- a/SourceCode/ETDValidator/ETDValidator/Program.cs
+++ b/SourceCode/ETDValidator/ETDValidator/Program.cs
@@ -22,5 +22,6 @@ namespace ETDVAlidator
                 {
                     webBuilder.UseStartup<Startup>();
                 });
+        
     }
 }

--- a/SourceCode/ETDValidator/ETDValidator/Startup.cs
+++ b/SourceCode/ETDValidator/ETDValidator/Startup.cs
@@ -31,7 +31,7 @@ namespace ETDVAlidator
         {
             if (env.IsDevelopment())
             {
-                app.UseDeveloperExceptionPage();
+                //app.UseDeveloperExceptionPage();
             }
             else
             {
@@ -39,6 +39,8 @@ namespace ETDVAlidator
                 // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
                 app.UseHsts();
             }
+            
+            
             app.UseHttpsRedirection();
             app.UseStaticFiles();
 

--- a/SourceCode/ETDValidator/ETDValidator/Views/Shared/_Layout.cshtml
+++ b/SourceCode/ETDValidator/ETDValidator/Views/Shared/_Layout.cshtml
@@ -6,6 +6,7 @@
     <title>@ViewData["Title"] - ETDVAlidator</title>
     <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="~/css/site.css" />
+    <script src="~/js/results-page.js"></script>
 </head>
 <body>
     <header>

--- a/SourceCode/ETDValidator/ETDValidator/Views/Validator/DocumentResults.cshtml
+++ b/SourceCode/ETDValidator/ETDValidator/Views/Validator/DocumentResults.cshtml
@@ -1,19 +1,22 @@
 @{
     ViewData["Title"] = "Uploader";
 }
-@model LoadDocumentViewModel
+@model DocumentResultsViewModel
+
 <link rel="stylesheet" href="~/css/upload-page.css">
+<script>
+// load JSON passed from backend in DocumentResultsViewModel
+// since we're accessing the view model, this needs to be done in the view file
+function retrieveJson() {
+    let jsonString = JSON.parse('@Model.JsonString'.replace(/&quot;/g, '\"'));
+    
+    // function for building
+    buildForm(jsonString);
+}
+retrieveJson();
+</script>
 
 
 <div class="text-center">
     <h1 class="display-4">ETD Uploader</h1>
-
-    @if (null != @ViewBag.xmlVal)
-    {
-        <p id="return-message">@ViewBag.xmlVal</p>
-    }
-    
 </div>
-
-
-<script src="~/js/upload-page.js"></script>

--- a/SourceCode/ETDValidator/ETDValidator/Views/Validator/LoadDocument.cshtml
+++ b/SourceCode/ETDValidator/ETDValidator/Views/Validator/LoadDocument.cshtml
@@ -9,16 +9,16 @@
     <h1 class="display-4">ETD Uploader</h1>
     
     <div id="file-loader-container" class="container-fluid">
-        @if (null != @ViewBag.xmlVal)
+        @if (null != @ViewBag.error)
         {
-            <p id="return-message">@ViewBag.xmlVal</p>
+            <p id="return-message">@ViewBag.error</p>
         }
         <form method="POST" asp-controller="Validator" asp-action="DocumentResults" enctype="multipart/form-data">
             <div class="drop-zone">
                 <span class="drop-zone__prompt">Drop file here or click to upload</span>
-                <input type="file" name="Document" accept=".docx" asp-for="Document" class="drop-zone__input">
+                <input type="file" name="Document" asp-for="Document" class="drop-zone__input">
             </div>
-            <input type="submit" id="drop-zone__submit" value="Upload File" class="submit"/>
+            <input type="submit" id="drop-zone__submit"  accept=".docx"  value="Upload File" class="submit"/>
         </form>
     </div>
     

--- a/SourceCode/ETDValidator/ETDValidator/wwwroot/js/results-page.js
+++ b/SourceCode/ETDValidator/ETDValidator/wwwroot/js/results-page.js
@@ -1,0 +1,6 @@
+// any components that are added for the validation UI can be added in this file
+
+// function is entry point into file from results view
+function buildValidationUI(jsonString) {
+    console.log(jsonString);
+}


### PR DESCRIPTION
## Overview
### `What is the change?`
- Upload now acutally accepts only .docx files
- JSON from backend can be interacted with in results-page.js

- [x] Bug Fix 
- [ ] New Feature
- [ ] Refactoring
- [ ] Other

### Trello card link?

https://trello.com/c/989CH2Rc/5-fix-the-current-bug-of-accepting-wrong-file-format-without-warning-bug-8

## Other Notes/Attachments

## `Meme`
